### PR TITLE
Add tests and CI (closes #5)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [18, 20, 22]
+
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+      
+      - run: npm install
+      - run: npm run lint
+      - run: npm test

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "creates unlimited public web URLs for your web servers no matter where they may be running",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "vitest run",
     "lint": "eslint . --ext .js",
     "dev": "nodemon --inspect run.js",
     "dev-brk": "nodemon --inspect-brk run.js",
@@ -38,6 +38,7 @@
     "eslint-plugin-import": "^2.25.2",
     "htm": "^3.0.4",
     "nodemon": "^3.0.1",
-    "preact": "^10.5.12"
+    "preact": "^10.5.12",
+    "vitest": "^2.0.0"
   }
 }

--- a/test/simple-parse.test.js
+++ b/test/simple-parse.test.js
@@ -1,0 +1,83 @@
+const { describe, it, expect } = require('vitest');
+const { parseReqHeaders, createParser } = require('../lib/simple-parse');
+
+describe('simple-parse', () => {
+  describe('parseReqHeaders', () => {
+    it('parses a simple GET request', async () => {
+      const request = Buffer.from(
+        'GET /path HTTP/1.1\r\n' +
+        'Host: example.com\r\n' +
+        'User-Agent: test\r\n' +
+        '\r\n'
+      );
+      
+      const result = await parseReqHeaders(request);
+      
+      expect(result.method).toBe('GET');
+      expect(result.url).toBe('/path');
+      expect(result.version).toBe('HTTP/1.1');
+      expect(result.headers.host).toBe('example.com');
+      expect(result.headers['user-agent']).toBe('test');
+      expect(result.headersFinished).toBe(true);
+    });
+
+    it('parses a POST request with content-type', async () => {
+      const request = Buffer.from(
+        'POST /api/data HTTP/1.1\r\n' +
+        'Host: api.example.com\r\n' +
+        'Content-Type: application/json\r\n' +
+        'Content-Length: 13\r\n' +
+        '\r\n' +
+        '{"foo":"bar"}'
+      );
+      
+      const result = await parseReqHeaders(request);
+      
+      expect(result.method).toBe('POST');
+      expect(result.url).toBe('/api/data');
+      expect(result.headers['content-type']).toBe('application/json');
+      expect(result.headers['content-length']).toBe('13');
+    });
+
+    it('handles missing host header', async () => {
+      const request = Buffer.from(
+        'GET / HTTP/1.1\r\n' +
+        '\r\n'
+      );
+      
+      const result = await parseReqHeaders(request);
+      
+      expect(result.headersFinished).toBe(false);
+    });
+  });
+
+  describe('createParser', () => {
+    it('creates a parser that resolves on complete headers', async () => {
+      const request = Buffer.from(
+        'GET /test HTTP/1.1\r\n' +
+        'Host: test.local\r\n' +
+        '\r\n'
+      );
+      
+      const parser = createParser(request);
+      const result = await parser.parse();
+      
+      expect(result.headersFinished).toBe(true);
+      expect(result.host).toBe('test.local');
+    });
+
+    it('can add data incrementally', async () => {
+      const part1 = Buffer.from('GET /test HTTP/1.1\r\n');
+      const part2 = Buffer.from('Host: incremental.local\r\n\r\n');
+      
+      const parser = createParser(part1);
+      const parsePromise = parser.parse();
+      
+      // Add remaining data
+      await parser.addData(part2);
+      
+      const result = await parsePromise;
+      expect(result.host).toBe('incremental.local');
+    });
+  });
+});


### PR DESCRIPTION
Adds tests and GitHub Actions CI for hsync-server.

## Changes
- Add vitest for testing
- Add tests for simple-parse module (parseReqHeaders, createParser)
- Add CI workflow running on Node 18/20/22

Closes #5